### PR TITLE
feat: improve details command

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,13 @@
                 <configuration>
                     <source>8</source>
                     <target>8</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>1.18.36</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <!-- To release to Maven central -->

--- a/src/main/java/cl/transbank/pos/utils/Serial.java
+++ b/src/main/java/cl/transbank/pos/utils/Serial.java
@@ -16,6 +16,7 @@ public class Serial {
     protected static final byte ACK = 0x06;
     protected static final byte NACK = 0x15;
     protected static final int MAX_NACK_ATTEMPTS = 2;
+    protected static final int CONSECUTIVE_EMPTY_AUTHCODE_LIMIT = 2;
     public static final int DEFAULT_TIMEOUT = 150000;
     public static final int DEFAULT_BAUDRATE = 115200;
     private static final long NANOSECONDS_PER_MILLISECOND = 1_000_000L;
@@ -133,16 +134,24 @@ public class Serial {
 
         if (saleDetail) {
             saleDetailResponse = new ArrayList<>();
-            String authorizationCode = "Start";
-            while (!authorizationCode.trim().isEmpty() && !printOnPOS) {
+            if (printOnPOS) {
+                return;
+            }
+
+            int consecutiveEmptyAuthCodes = 0;
+
+            while (consecutiveEmptyAuthCodes < CONSECUTIVE_EMPTY_AUTHCODE_LIMIT) {
                 readMessage();
                 try {
-                    authorizationCode = getAuthorizationCode(currentResponse);
-                    if (!authorizationCode.trim().isEmpty()) {
+                    String authorizationCode = getAuthorizationCode(currentResponse);
+                    if (authorizationCode != null && !authorizationCode.trim().isEmpty()) {
                         saleDetailResponse.add(currentResponse);
+                        consecutiveEmptyAuthCodes = 0;
+                    } else {
+                        consecutiveEmptyAuthCodes++; 
                     }
                 } catch (IndexOutOfBoundsException e) {
-                    authorizationCode = "";
+                    consecutiveEmptyAuthCodes++;
                 }
             }
             return;


### PR DESCRIPTION
This PR improves the mechanism to handle the saleDetails command, so the SDK understands that after 2 sequential messages with no authCode means the list of sales has finished. Additionally has been added the Lombok annotation proccesor path to fix critical errors during compilation.

## Tests

**Before:** SDK cuts the message stream at the end of saleDetails command
<img width="1153" height="145" alt="Captura de pantalla 2025-11-26 a las 08 01 16" src="https://github.com/user-attachments/assets/da31c834-d4a7-47b9-a268-683634f7286b" />

**After:** SDK expects two messages with no authCode so it understands the sale list has finished
<img width="1154" height="222" alt="Captura de pantalla 2025-11-26 a las 08 01 28" src="https://github.com/user-attachments/assets/a57bbfc7-2f17-49ad-b508-d096d6d3190b" />
